### PR TITLE
Add logic for damage text color difference

### DIFF
--- a/Assets/Prefabs/DamageManager.prefab
+++ b/Assets/Prefabs/DamageManager.prefab
@@ -45,3 +45,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   damageObjectPrefab: {fileID: 968034584677551715, guid: fdbdfb319c18d4d5a9d69a6c41316043, type: 3}
+  playerDamageColor: {r: 1, g: 0.24550551, b: 0, a: 1}
+  enemyDamageColor: {r: 1, g: 0.7469876, b: 0, a: 1}

--- a/Assets/Prefabs/DamageObject.prefab
+++ b/Assets/Prefabs/DamageObject.prefab
@@ -180,8 +180,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278214911
-  m_fontColor: {r: 1, g: 0.3746573, b: 0, a: 1}
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:

--- a/Assets/Scripts/DamageObjectBehaviour.cs
+++ b/Assets/Scripts/DamageObjectBehaviour.cs
@@ -18,8 +18,9 @@ public class DamageObjectBehaviour : MonoBehaviour
         transform.localRotation *= Quaternion.Euler(0f, 180f, 0f);
     }
 
-    public void Initialize(string damageText)
+    public void Initialize(string damageText, Color color)
     {
         text.text = damageText;
+        text.color = color;
     }
 }

--- a/Assets/Scripts/DamageObjectSpawner.cs
+++ b/Assets/Scripts/DamageObjectSpawner.cs
@@ -5,6 +5,8 @@ public class DamageObjectSpawner : MonoBehaviour
     public static DamageObjectSpawner Instance { get; private set; }
 
     [SerializeField] private GameObject damageObjectPrefab;
+    [SerializeField] private Color playerDamageColor;
+    [SerializeField] private Color enemyDamageColor;
 
     private const int MinimumScaleDamageAmount = 5;
     private const int MaximumScaleDamageAmount = 30;
@@ -27,14 +29,12 @@ public class DamageObjectSpawner : MonoBehaviour
         }
     }
 
-    public void SpawnDamageObject(int damageAmount, Vector3 position, Transform parent = null)
+    public void SpawnDamageObject(int damageAmount, Vector3 position, bool isPlayer = false)
     {
-        var damageObject = parent
-            ? Instantiate(damageObjectPrefab, position, Quaternion.identity, parent)
-            : Instantiate(damageObjectPrefab, position, Quaternion.identity);
+        var damageObject = Instantiate(damageObjectPrefab, position, Quaternion.identity);
 
         var damageObjectBehaviour = damageObject.GetComponent<DamageObjectBehaviour>();
-        damageObjectBehaviour.Initialize(damageAmount.ToString());
+        damageObjectBehaviour.Initialize(damageAmount.ToString(), isPlayer ? playerDamageColor : enemyDamageColor);
 
         damageObject.transform.localScale = Vector3.one * damageAmount switch
         {

--- a/Assets/Scripts/EntityControl/EntityController.cs
+++ b/Assets/Scripts/EntityControl/EntityController.cs
@@ -40,6 +40,8 @@ public class EntityController : MonoBehaviour
     
     public float dodgeDash;
 
+    protected bool isPlayer;
+
     public AttackContextsSO attackContextSO;
 
     protected virtual void Awake()
@@ -111,7 +113,7 @@ public class EntityController : MonoBehaviour
 
         hp -= CalculateDamage(ctx.damage);
         
-        DamageObjectSpawner.Instance.SpawnDamageObject((int) ctx.damage, transform.position + Vector3.up);
+        DamageObjectSpawner.Instance.SpawnDamageObject((int) ctx.damage, transform.position + Vector3.up, isPlayer);
 
         return true;
     }

--- a/Assets/Scripts/EntityControl/PlayerController.cs
+++ b/Assets/Scripts/EntityControl/PlayerController.cs
@@ -26,6 +26,8 @@ public class PlayerController : EntityController
 
         StateMachine = new PlayerStateMachine(this);
 
+        isPlayer = true;
+
         hp = maxHp;
         mp = maxMp;
         


### PR DESCRIPTION
Add logic for damage text color select.

Look for `isPlayer` param of function:
```cs
DamageObjectSpawner.SpawnDamageObject(int damageAmount, Vector3 position, bool isPlayer = false)
```

Color can be adjusted by modifying `playerDamageColor` and `enemyDamageColor` of `DamageManager` prefab.

<img width="371" height="120" alt="Screenshot 2025-08-07 at 22 47 48" src="https://github.com/user-attachments/assets/46c3b021-4fa9-482f-8533-a7dd4677e2d2" />